### PR TITLE
Added option to overwrite smaller; statistics

### DIFF
--- a/coverlovin.py
+++ b/coverlovin.py
@@ -47,7 +47,7 @@ def sanitise_for_url(inputString):
 
     return outputString
 
-def dl_cover(urlList, directory, fileName, overWrite=False):
+def dl_cover(urlList, directory, fileName, overWrite=False, larger=False):
     '''download cover image from url in list to given directory/fileName'''
 
     coverImg = os.path.join(directory, fileName)
@@ -266,6 +266,7 @@ def main():
     referer = unicode(parameters['referer'], 'utf-8')
     resultCount = parameters['resultCount']
     overWrite = parameters['overWrite']
+    larger = parameters['larger']
     debug = parameters['debug']
     # set loglevel to debug
     if debug:
@@ -290,8 +291,8 @@ def main():
                 dl_cover(urls, directory, fileName, overWrite=overWrite, larger=larger)
             else:
                 log.info('no urls found for %s/%s' % (artist, album))
-        except:
-            print "An error occured during fatching the image urls"
+        except Exception, err:
+            print "An error occured during fetching the image urls: %s" % err
 
     return 0
 

--- a/coverlovin.py
+++ b/coverlovin.py
@@ -14,6 +14,7 @@ from LoadFile import LoadFile
 import logging
 from optparse import OptionParser
 from PIL import Image
+from time import time
 
 # logging
 log = logging.getLogger('coverlovin')
@@ -252,9 +253,19 @@ def parse_args_opts():
 
     return parameters
 
+# utility function to format time
+def hms_time(sec_elapsed):
+    h = int(sec_elapsed / (60 * 60))
+    m = int((sec_elapsed % (60 * 60)) / 60)
+    s = sec_elapsed % 60.
+    return "{}:{:>02}:{:>05.2f}".format(h, m, s)
+
 def main():
     '''recursively download cover images for music files in a
     given directory and its sub-directories'''
+
+    # record start time
+    start_time = time()
 
     parameters = parse_args_opts()
 
@@ -293,6 +304,10 @@ def main():
                 log.info('no urls found for %s/%s' % (artist, album))
         except Exception, err:
             print "An error occured during fetching the image urls: %s" % err
+
+    # record end time
+    end_time = time()
+    print "Total time elapsed: %s" % hms_time(end_time-start_time)
 
     return 0
 


### PR DESCRIPTION
Added a few things I wanted to coverlovin. Others may also like them.
- Option to overwrite only smaller images (-l / --larger)
  - adds dependency on PIL
- Elapsed time to run
- Totals for albums, network requests, and covers added
- fixed typo and added extra output on error

Feel free to pick and choose, just figured since you have the more canonical repo it would be nice to see these features added. They seem to work from my testing and usage, but no guarantees.

It's worth noting that for the overwrite smaller only option even smaller images must be downloaded to check the size, so even though less covers may be replaced, the same number will be downloaded.

Thanks,
Dan
